### PR TITLE
Prevent IE from detecting backspace event

### DIFF
--- a/src/ng-select/ng-select.component.ts
+++ b/src/ng-select/ng-select.component.ts
@@ -259,6 +259,7 @@ export class NgSelectComponent implements OnDestroy, OnChanges, AfterViewInit, C
                     break;
                 case KeyCode.Backspace:
                     this._handleBackspace();
+                    $event.stopPropagation();
                     break;
             }
         } else if ($event.key && $event.key.length === 1) {


### PR DESCRIPTION
Stop propagation of backspace event to prevent IE11 from detecting it